### PR TITLE
Change wg-easy image

### DIFF
--- a/src/apps/wg-easy/docker-compose.yml
+++ b/src/apps/wg-easy/docker-compose.yml
@@ -1,7 +1,7 @@
 name: wg-easy
 services:
   app:
-    image: weejewel/wg-easy
+    image: ghcr.io/wg-easy/wg-easy
     environment:
       WG_HOST: 0.0.0.0
       PASSWORD: casaos


### PR DESCRIPTION
The current version of `weejewel/wg-easy` is old and not maintained. Also I don't see the point of using this old forked image instead of the official one `ghcr.io/wg-easy/wg-easy` from the [official repo](https://github.com/wg-easy/wg-easy).

Update prompted from the current wg-easy app :
![image](https://github.com/WisdomSky/CasaOS-Coolstore/assets/21091232/e03f14e1-593f-4338-a3f5-62eb8a382423)

The repository is archived :
![image](https://github.com/WisdomSky/CasaOS-Coolstore/assets/21091232/417f6803-c3eb-46df-9508-f973b9f69554)

So it should be better to use `ghcr.io/wg-easy/wg-easy` as `wg-easy` image.

I guess that the latest stable image version number is added as image version tag in the final CasaOS app config file ?