### PR TITLE
fix Github container registry tag fetching

### DIFF
--- a/src/classes/handlers/github.ts
+++ b/src/classes/handlers/github.ts
@@ -20,13 +20,13 @@ export default class GithubRepositoryHandler extends ContainerRepositoryHandler 
         try {
             do {
 
-                if (page >= 10) throw 'Scanned 10 pages. Surrendering...';
+                if (page >= 100) throw 'Scanned 100 pages. Surrendering...';
 
                 const imageinfo = image.replace(/^(?:ghcr\.io\/)?([^\/]+?\/[^\/\:]+?)(?:\:[^\/\:]+)?$/,'$1').split('/');
 
-                this.context.log(`https://api.github.com/users/${imageinfo[0]}/packages/container/${imageinfo[1]}/versions?page=${page++}`)
+                this.context.log(`https://api.github.com/users/${imageinfo[0]}/packages/container/${imageinfo[1]}/versions?page=${page}`)
 
-                let results: GithubTag[] = await this.fetchJson<GithubTag[]>(`https://api.github.com/users/${imageinfo[0]}/packages/container/${imageinfo[1]}/versions?page=${page++}`,{
+                let results: GithubTag[] = await this.fetchJson<GithubTag[]>(`https://api.github.com/users/${imageinfo[0]}/packages/container/${imageinfo[1]}/versions?page=${page}`,{
                     headers: {
                         Authorization: `Bearer ${process.env.GITHUB_ACCESS_TOKEN}`
                     }
@@ -51,6 +51,7 @@ export default class GithubRepositoryHandler extends ContainerRepositoryHandler 
                 } catch (e) {
                     this.context.log(results);
                 }
+                page++
             } while (true);
         } catch(e) {
             this.context.log(e);


### PR DESCRIPTION
The previous Github container registry tag fetching was broken, as it was incrementing page index before getting the results :

![image](https://github.com/WisdomSky/CasaOS-Cool-Appstore-Generator/assets/21091232/cc88fd60-3d35-4025-8593-24de385827f7)

Resulting in odd pages being skipped :

![image](https://github.com/WisdomSky/CasaOS-Cool-Appstore-Generator/assets/21091232/8ec1ec57-127c-4b5a-a1b9-b901eae6c2f6)

So I fixed it and also increased the 10 pages limit to 100, because the tag for `wg-easy` is page 23 :

![image](https://github.com/WisdomSky/CasaOS-Cool-Appstore-Generator/assets/21091232/916ddf9e-2a1f-4ecb-9b3d-14e3f42a396a)
(for some reason they are pushing a lot of untagged images)