### PR TITLE
add tika & gotenberg in paperless

### DIFF
--- a/src/apps/paperless-ngx/docker-compose.yml
+++ b/src/apps/paperless-ngx/docker-compose.yml
@@ -27,6 +27,9 @@ services:
       PAPERLESS_DBPORT: 3306
       PAPERLESS_ADMIN_USER: admin
       PAPERLESS_ADMIN_PASSWORD: admin
+      PAPERLESS_TIKA_ENABLED: 1
+      PAPERLESS_TIKA_GOTENBERG_ENDPOINT: http://gotenberg:3000
+      PAPERLESS_TIKA_ENDPOINT: http://tika:9998
   broker:
     image: redis
     restart: unless-stopped
@@ -43,6 +46,24 @@ services:
       MARIADB_USER: paperless
       MARIADB_PASSWORD: paperless
       MARIADB_ROOT_PASSWORD: paperless
+  tika:
+    image: ghcr.io/paperless-ngx/tika:latest
+    restart: unless-stopped
+    ports: 
+      - "9998:9998"
+  gotenberg:
+    image: docker.io/gotenberg/gotenberg:7.10
+    restart: unless-stopped
+
+    # The gotenberg chromium route is used to convert .eml files. We do not
+    # want to allow external content like tracking pixels or even javascript.
+    command:
+      - "gotenberg"
+      - "--chromium-disable-javascript=true"
+      - "--chromium-allow-list=file:///tmp/.*"
+    ports: 
+      - "3000:3000"
+  
 x-casaos:
   architectures:
     - amd64


### PR DESCRIPTION
Add optional services for Paperless NGX to process office files https://docs.paperless-ngx.com/configuration/#optional-services

Config copied from official template
https://github.com/paperless-ngx/paperless-ngx/blob/main/docker/compose/docker-compose.mariadb-tika.yml